### PR TITLE
Deduplicate events via uid

### DIFF
--- a/my_hebrew_dates/hebcal/utils.py
+++ b/my_hebrew_dates/hebcal/utils.py
@@ -24,8 +24,10 @@ def generate_ical(modelCalendar: ModelCalendar):
         hebrewDate: HebrewDate = hebrewDate
         for engDate in hebrewDate.get_english_dates():
             engDate: date = engDate
-            eventHash = sha1((hebrewDate.event_type + hebrewDate.name + hebrewDate.get_hebrew_date()).encode("utf-8")).digest()
-            uid = date.isoformat() + urlsafe_b64encode(eventHash).decode("ascii") + "@myhebrewdates.com"
+            eventHash = sha1(
+                (hebrewDate.event_type + hebrewDate.name + hebrewDate.get_hebrew_date()).encode("utf-8")
+            ).digest()
+            uid = engDate.isoformat() + urlsafe_b64encode(eventHash).decode("ascii") + "@myhebrewdates.com"
             event = Event()
             event.add("summary", hebrewDate.event_type + " " + hebrewDate.name)
             event.add("description", hebrewDate.get_hebrew_date() + "\n Brought to you by: MyHebrewDates.com")

--- a/my_hebrew_dates/hebcal/utils.py
+++ b/my_hebrew_dates/hebcal/utils.py
@@ -1,4 +1,6 @@
+from base64 import urlsafe_b64encode
 from datetime import date
+from hashlib import sha1
 
 from icalendar import Calendar, Event, Timezone
 
@@ -22,11 +24,14 @@ def generate_ical(modelCalendar: ModelCalendar):
         hebrewDate: HebrewDate = hebrewDate
         for engDate in hebrewDate.get_english_dates():
             engDate: date = engDate
+            eventHash = sha1((hebrewDate.event_type + hebrewDate.name + hebrewDate.get_hebrew_date()).encode("utf-8")).digest()
+            uid = date.isoformat() + urlsafe_b64encode(eventHash).decode("ascii") + "@myhebrewdates.com"
             event = Event()
             event.add("summary", hebrewDate.event_type + " " + hebrewDate.name)
             event.add("description", hebrewDate.get_hebrew_date() + "\n Brought to you by: MyHebrewDates.com")
             event.add("dtstart", engDate)
             event.add("dtend", engDate)
+            event.add("uid", uid)
             events.append(event)
 
     sorted_events = sorted(events, key=lambda e: e["dtstart"].dt)


### PR DESCRIPTION
add a uid to events of the form: date, base 64 hash of (event type + name + hebrew date), and the domain.

This conforms to the ical uid spec, and most clients should deduplicate events with the same uid from different calendars. the use case is if one enters the same birthday in different family calendars, the event should only show once, as it is really the same event

untested