### PR TITLE
Fix: validate Hebrew date day against month length

### DIFF
--- a/my_hebrew_dates/hebcal/forms.py
+++ b/my_hebrew_dates/hebcal/forms.py
@@ -79,9 +79,10 @@ class HebrewDateForm(forms.ModelForm):
             max_days = lengths_of_months[month]
             if day > max_days:
                 month_name = HebrewMonthEnum(month).label
-                raise ValidationError(
+                msg = (
                     f"{month_name} only has {max_days} days. "
-                    f"Please select a valid day (1–{max_days}).",
+                    f"Please select a valid day (1-{max_days})."
                 )
+                raise ValidationError(msg)
 
         return cleaned_data

--- a/my_hebrew_dates/hebcal/forms.py
+++ b/my_hebrew_dates/hebcal/forms.py
@@ -6,9 +6,12 @@ from crispy_forms.layout import Div
 from crispy_forms.layout import Layout
 from crispy_forms.layout import Row
 from django import forms
+from django.core.exceptions import ValidationError
 
+from .hebrew_date import lengths_of_months
 from .models import Calendar
 from .models import HebrewDate
+from .models import HebrewMonthEnum
 
 
 class CalendarForm(forms.ModelForm):
@@ -66,3 +69,19 @@ class HebrewDateForm(forms.ModelForm):
         )
 
         self.helper.form_show_labels = False
+
+    def clean(self):
+        cleaned_data = super().clean()
+        month = cleaned_data.get("month")
+        day = cleaned_data.get("day")
+
+        if month is not None and day is not None:
+            max_days = lengths_of_months[month]
+            if day > max_days:
+                month_name = HebrewMonthEnum(month).label
+                raise ValidationError(
+                    f"{month_name} only has {max_days} days. "
+                    f"Please select a valid day (1–{max_days}).",
+                )
+
+        return cleaned_data

--- a/my_hebrew_dates/hebcal/tests/test_forms.py
+++ b/my_hebrew_dates/hebcal/tests/test_forms.py
@@ -71,6 +71,28 @@ class TestHebrewDateForm(TestCase):
         assert not form.is_valid()
         assert "event_type" in form.errors
 
+    def test_hebrew_date_form_day_exceeds_month_length(self):
+        """Test that day 30 is rejected for months with only 29 days (e.g. Iyar)."""
+        form = HebrewDateForm(
+            data={"name": "Test Date", "month": 2, "day": 30, "event_type": "🎂"},
+        )
+        assert not form.is_valid()
+        assert "__all__" in form.errors
+
+    def test_hebrew_date_form_max_day_for_29_day_month(self):
+        """Test that day 29 is accepted for 29-day months (e.g. Iyar)."""
+        form = HebrewDateForm(
+            data={"name": "Test Date", "month": 2, "day": 29, "event_type": "🎂"},
+        )
+        assert form.is_valid()
+
+    def test_hebrew_date_form_day_30_valid_for_30_day_month(self):
+        """Test that day 30 is accepted for 30-day months (e.g. Nisan)."""
+        form = HebrewDateForm(
+            data={"name": "Test Date", "month": 1, "day": 30, "event_type": "🎂"},
+        )
+        assert form.is_valid()
+
     def test_hebrew_date_form_initialization_with_instance(self):
         self.user = User.objects.create_user(
             username="testuser",

--- a/my_hebrew_dates/hebcal/tests/test_forms.py
+++ b/my_hebrew_dates/hebcal/tests/test_forms.py
@@ -78,6 +78,9 @@ class TestHebrewDateForm(TestCase):
         )
         assert not form.is_valid()
         assert "__all__" in form.errors
+        error_message = form.errors["__all__"][0]
+        assert "only has 29 days" in error_message
+        assert "1-29" in error_message
 
     def test_hebrew_date_form_max_day_for_29_day_month(self):
         """Test that day 29 is accepted for 29-day months (e.g. Iyar)."""


### PR DESCRIPTION
## Summary

- Adds form-level validation to `HebrewDateForm` that rejects day values exceeding the month's actual length (e.g., day 30 for Iyar which only has 29 days)
- Uses the existing `lengths_of_months` lookup from `hebrew_date.py` for the validation check
- Returns a clear error message with the month name and valid day range
- Adds 3 test cases covering invalid day, valid boundary day, and valid 30-day month

## Problem

The UI allows selecting any day (1–30) for any Hebrew month, but some months only have 29 days. Submitting day 30 for a 29-day month (Iyar, Tammuz, Elul, Tevet, Adar B) causes an unhandled 500 error.

## Test plan

- [ ] Select Iyar + day 30 → form shows validation error instead of 500
- [ ] Select Nisan + day 30 → form submits successfully
- [ ] Select Iyar + day 29 → form submits successfully
- [ ] Run `pytest my_hebrew_dates/hebcal/tests/test_forms.py` → all tests pass

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)