### PR TITLE
Explicitly configure stdout stream for console logging handler

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -184,6 +184,7 @@ LOGGING = {
         "console": {
             "level": "DEBUG",
             "class": "logging.StreamHandler",
+            "stream": "ext://sys.stdout",
             "formatter": "json",
         },
     },


### PR DESCRIPTION
## Summary
Explicitly configure the console logging handler to use `sys.stdout` as its output stream in production settings.

## Changes
- Added `"stream": "ext://sys.stdout"` to the console handler configuration in `config/settings/production.py`

## Details
This change makes the stream destination explicit for the console logging handler. By using the `ext://` prefix with `sys.stdout`, we ensure that log output is directed to standard output in a clear and maintainable way. This is particularly important in production environments where logging behavior needs to be predictable and properly configured.

The `ext://` syntax allows the logging configuration to reference external objects (in this case, `sys.stdout`) through the logging configuration dictionary, which is a standard Python logging practice.

https://claude.ai/code/session_01UDM7AyAh25CsyjF1rTY4Lb